### PR TITLE
Adds `clearAuthentication` method

### DIFF
--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -123,6 +123,11 @@ class MetricsConnection {
     _setAuthStatus(AuthenticationState.unknown);
   }
 
+  /// Clears the internal authentication state by removing all tokens
+  void clearAuthentication() {
+    _setAuthStatus(AuthenticationState.unauthenticated);
+  }
+
   void _openSocket() async {
     if (isSocketConnected) {
       _closeSocket();

--- a/test/keiser_metrics_connection_test.dart
+++ b/test/keiser_metrics_connection_test.dart
@@ -178,6 +178,15 @@ void main() {
         expect(authenticationState, AuthenticationState.authenticated);
       });
 
+      test('Can clear authentication state', () async {
+        connection!.clearAuthentication();
+
+        await Future.delayed(const Duration(seconds: 1));
+        expect(authenticationState, AuthenticationState.unauthenticated);
+        expect(connection!.decodedAccesstoken, isNull);
+        expect(connection!.isSocketConnected, true);
+      });
+
       test('Can close Metrics Connection', () async {
         connection!.close();
 


### PR DESCRIPTION
The point of this method is to clear the internal auth state of the connection class when a user logs out. 