### PR TITLE
Updates error model to include params from API

### DIFF
--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -7,6 +7,7 @@ class MetricsApiError implements Exception {
     required this.status,
     required this.name,
     required this.message,
+    this.params,
   });
 
   String? explanation;
@@ -14,6 +15,7 @@ class MetricsApiError implements Exception {
   int status;
   String name;
   String message;
+  dynamic params;
 
   factory MetricsApiError.fromMap(Map<String, dynamic> json) => MetricsApiError(
         explanation: json["explanation"],
@@ -21,6 +23,7 @@ class MetricsApiError implements Exception {
         status: json["status"],
         name: json["name"],
         message: json["message"],
+        params: json["params"],
       );
 
   Map<String, dynamic> toMap() => {
@@ -29,11 +32,12 @@ class MetricsApiError implements Exception {
         "status": status,
         "name": name,
         "message": message,
+        "params": params,
       };
 
   @override
   String toString() {
-    return 'Error(code: $code, explanation: $explanation, status: $status,name: $name, message: $message)';
+    return 'Error(code: $code, explanation: $explanation, status: $status,name: $name, message: $message, params: $params)';
   }
 }
 

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -15,7 +15,7 @@ class MetricsApiError implements Exception {
   int status;
   String name;
   String message;
-  dynamic params;
+  List<String>? params;
 
   factory MetricsApiError.fromMap(Map<String, dynamic> json) => MetricsApiError(
         explanation: json["explanation"],
@@ -23,7 +23,7 @@ class MetricsApiError implements Exception {
         status: json["status"],
         name: json["name"],
         message: json["message"],
-        params: json["params"],
+        params: _convertParamsToStringList(json["params"]),
       );
 
   Map<String, dynamic> toMap() => {
@@ -34,6 +34,18 @@ class MetricsApiError implements Exception {
         "message": message,
         "params": params,
       };
+
+    static List<String>? _convertParamsToStringList(dynamic params) {
+    if (params is List<String>) {
+      return params;
+    } else if (params is List) {
+      return params.map((e) => e.toString()).toList();
+    } else if (params is String) {
+      return [params];
+    } else {
+      return null;
+    }
+  }
 
   @override
   String toString() {


### PR DESCRIPTION
Most of the params sent from the API are lists of strings, but there are some edge cases where params is a list of numbers or just a string.
Converts various params typing from the API into a List of strings.