### PR TITLE
v2.0.0

### DIFF
--- a/.github/workflows/dev-mirror.yml
+++ b/.github/workflows/dev-mirror.yml
@@ -97,7 +97,6 @@ jobs:
           # Validate exactly what consumers will pull, before mirroring.
           dart pub get
           dart analyze
-          dart pub publish --dry-run
 
           git add pubspec.yaml
           git commit -m "chore: dev build ${VER}-dev.${N}"

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:flutter_lints/flutter.yaml
+include: package:lints/recommended.yaml
 
 # Additional information about this file can be found at
 # https://dart.dev/guides/language/analysis-options

--- a/example/main.dart
+++ b/example/main.dart
@@ -24,8 +24,6 @@ void main() {
     _isAuthenticated = event == AuthenticationState.authenticated;
     _printStatus();
   });
-
-  connection.open();
 }
 
 void _printStatus() {

--- a/lib/keiser_metrics_connection.dart
+++ b/lib/keiser_metrics_connection.dart
@@ -9,7 +9,7 @@ import 'package:enum_to_string/enum_to_string.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:retry/retry.dart';
 import 'package:web_socket_channel/status.dart' as socket_status;
-import 'package:web_socket_channel/web_socket_channel.dart';
+import 'package:web_socket_channel/io.dart';
 
 import 'src/internal.dart';
 

--- a/lib/keiser_metrics_connection.dart
+++ b/lib/keiser_metrics_connection.dart
@@ -3,17 +3,19 @@ library keiser_metrics_connection;
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:dio/dio.dart';
 import 'package:enum_to_string/enum_to_string.dart';
 import 'package:jwt_decoder/jwt_decoder.dart';
 import 'package:retry/retry.dart';
-import 'package:web_socket_channel/status.dart' as socket_status;
 import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/status.dart' as socket_status;
 
 import 'src/internal.dart';
 
 part 'src/connection.dart';
+part 'src/connection_helpers.dart';
 part 'src/constants.dart';
 part 'src/errors.dart';
 part 'src/jwt.dart';

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -327,7 +327,7 @@ class MetricsConnection {
 
   Future<void> _retrySocketConnection() async {
     _socketRetryAttempts++;
-    await Future.delayed(nextReconnectDelay(_socketRetryAttempts));
+    await Future.delayed(_nextReconnectDelay(_socketRetryAttempts));
     if (shouldEnableErrorLogging) {
       print('Retrying socket connection...');
     }
@@ -336,7 +336,7 @@ class MetricsConnection {
 
   Future<void> _retryRestConnection() async {
     _restRetryAttempts++;
-    await Future.delayed(nextReconnectDelay(_restRetryAttempts));
+    await Future.delayed(_nextReconnectDelay(_restRetryAttempts));
     if (shouldEnableErrorLogging) {
       print('Retrying REST connection...');
     }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -49,6 +49,7 @@ class MetricsConnection {
   String? _accessToken;
   String? _refreshToken;
   Timer? _accessTokenTimer;
+  Timer? _inactivityTimer;
   bool _isRefreshTokenInUse = false;
   StreamSubscription? _socketSubscription;
 
@@ -160,11 +161,11 @@ class MetricsConnection {
     _shouldRetrySocketConnection = true;
     _socket = IOWebSocketChannel.connect(
       Uri.parse(socketEndpoint),
-      pingInterval: const Duration(seconds: 30),
       connectTimeout: socketTimeout,
     );
     try {
       await _socket!.ready;
+      _resetInactivityTimer();
       _socketSubscription = _socket!.stream.listen(
         _onSocketMessage,
         onError: _onSocketError,
@@ -180,12 +181,24 @@ class MetricsConnection {
   }
 
   void _closeSocket() {
+    _inactivityTimer?.cancel();
+    _inactivityTimer = null;
     _socketSubscription?.cancel();
     _socketSubscription = null;
     _socket?.sink.close(socket_status.normalClosure);
     _socket = null;
     _setConnectionState(ConnectionState.disconnected);
     _drainSocket();
+  }
+
+  void _resetInactivityTimer() {
+    _inactivityTimer?.cancel();
+    _inactivityTimer = Timer(const Duration(seconds: 75), () {
+      if (shouldEnableErrorLogging) {
+        print('Socket inactivity timeout');
+      }
+      _onSocketDone();
+    });
   }
 
   void _openRest() {
@@ -290,6 +303,7 @@ class MetricsConnection {
   }
 
   void _onSocketMessage(dynamic data) {
+    _resetInactivityTimer();
     try {
       final parsedJson = jsonDecode(data);
       if (parsedJson is String) {

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -36,7 +36,7 @@ class MetricsConnection {
   final int? socketRetryTimeout;
 
   // internal
-  WebSocketChannel? _socket;
+  IOWebSocketChannel? _socket;
   Dio? _dio;
   int _lastMessageId = 0;
   int _socketRetryAttempts = 0;
@@ -122,8 +122,17 @@ class MetricsConnection {
     _shouldRetrySocketConnection = false;
     _closeSocket();
     _closeRest();
-    _drainPendingRequests();
     _setAuthStatus(AuthenticationState.unknown);
+  }
+
+  void _drainSocket() {
+    final error = UnexpectedError(message: 'Socket connection closed');
+    for (final completer in _completers.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(error);
+      }
+    }
+    _completers.clear();
   }
 
   /// Error-completes every in-flight request so awaiters are released instead
@@ -131,13 +140,6 @@ class MetricsConnection {
   /// socket completers map and the queued REST/socket requests.
   void _drainPendingRequests() {
     final error = UnexpectedError(message: 'Connection closed');
-    for (final completer in _completers.values) {
-      if (!completer.isCompleted) {
-        completer.completeError(error);
-      }
-    }
-    _completers.clear();
-
     for (final request in _requestQueue) {
       if (!request.completer.isCompleted) {
         request.completer.completeError(error);
@@ -156,11 +158,13 @@ class MetricsConnection {
       _closeSocket();
     }
     _shouldRetrySocketConnection = true;
-    _socket = WebSocketChannel.connect(
+    _socket = IOWebSocketChannel.connect(
       Uri.parse(socketEndpoint),
+      pingInterval: const Duration(seconds: 30),
+      connectTimeout: socketTimeout,
     );
     try {
-      await _socket!.ready.timeout(socketTimeout);
+      await _socket!.ready;
       _socketSubscription = _socket!.stream.listen(
         _onSocketMessage,
         onError: _onSocketError,
@@ -181,6 +185,7 @@ class MetricsConnection {
     _socket?.sink.close(socket_status.normalClosure);
     _socket = null;
     _setConnectionState(ConnectionState.disconnected);
+    _drainSocket();
   }
 
   void _openRest() {
@@ -200,6 +205,7 @@ class MetricsConnection {
     _isDioAvailable = false;
     _dio = null;
     _setServerStatus(ServerState.offline);
+    _drainPendingRequests();
   }
 
   /// A single REST request failing with a connection-class error must not
@@ -217,6 +223,7 @@ class MetricsConnection {
 
   void _onSocketError(error) {
     _setConnectionState(ConnectionState.disconnected);
+    _onSocketDone();
     if (shouldEnableErrorLogging) {
       print('Socket Error: $error');
     }

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -1,4 +1,4 @@
-part of keiser_metrics_connection;
+part of '../keiser_metrics_connection.dart';
 
 class MetricsConnection {
   /// Creates a new instance of [MetricsConnection].

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -10,7 +10,6 @@ class MetricsConnection {
   /// [concurrentRequestLimit] is the limit for concurrent requests.
   /// [requestRetryLimit] is the limit for request retries.
   /// [shouldEnableErrorLogging] is a flag indicating whether to enable error logging or not.
-  /// [socketRetryTimeout] is the timeout in milliseconds for socket retry attempts.
   MetricsConnection({
     this.restEndpoint = defaultRestEndpoint,
     this.socketEndpoint = defaultSocketEndpoint,
@@ -20,9 +19,8 @@ class MetricsConnection {
     this.concurrentRequestLimit = defaultConcurrentRequestLimit,
     this.requestRetryLimit = defaultRequestRetryLimit,
     this.shouldEnableErrorLogging = false,
-    this.socketRetryTimeout,
   }) {
-    open();
+    unawaited(_open());
   }
   // params
   final String restEndpoint;
@@ -33,13 +31,13 @@ class MetricsConnection {
   final Duration socketTimeout;
   final Duration socketMessageTimeout;
   final bool shouldEnableErrorLogging;
-  final int? socketRetryTimeout;
 
   // internal
   IOWebSocketChannel? _socket;
   Dio? _dio;
   int _lastMessageId = 0;
   int _socketRetryAttempts = 0;
+  int _restRetryAttempts = 0;
   bool _shouldRetrySocketConnection = true;
   bool _isDioAvailable = false;
   final List<RequestHandler> _requestQueue = [];
@@ -50,7 +48,9 @@ class MetricsConnection {
   String? _refreshToken;
   Timer? _accessTokenTimer;
   Timer? _inactivityTimer;
+  Timer? _stabilityTimer;
   bool _isRefreshTokenInUse = false;
+  Completer<void>? _refreshCompleter;
   StreamSubscription? _socketSubscription;
 
   // state
@@ -101,16 +101,15 @@ class MetricsConnection {
       _accessToken != null ? decodeJwt(_accessToken!) : null;
 
   /// Opens the websocket and REST connections.
-  void open() {
+  Future<void> _open() async {
     if (_isOpen) {
       return;
     }
     _isOpen = true;
-    _openRest();
-
     if (shouldEnableWebSocket) {
-      _openSocket();
+      await _openSocket();
     }
+    await _openRest();
   }
 
   /// Closes the websocket and rest connections.
@@ -119,11 +118,24 @@ class MetricsConnection {
   /// be active. If you want to close & dispose of the instance, use the
   /// `dispose` method instead.
   void close() {
-    _isOpen = false;
     _shouldRetrySocketConnection = false;
     _closeSocket();
     _closeRest();
+    // Tear down lifecycle timers unconditionally. `_setAuthStatus(unknown)`
+    // does NOT clear the access-token (keep-alive) timer — only the
+    // `unauthenticated` branch does — so cancel it here or it keeps firing
+    // requests against a closed connection.
+    _accessTokenTimer?.cancel();
+    _accessTokenTimer = null;
+    _inactivityTimer?.cancel();
+    _inactivityTimer = null;
+    _stabilityTimer?.cancel();
+    _stabilityTimer = null;
+    // Reset backoff so a later reopen does not start deep in the delay curve.
+    _socketRetryAttempts = 0;
+    _restRetryAttempts = 0;
     _setAuthStatus(AuthenticationState.unknown);
+    _isOpen = false;
   }
 
   void _drainSocket() {
@@ -154,9 +166,18 @@ class MetricsConnection {
     _setAuthStatus(AuthenticationState.unauthenticated);
   }
 
-  void _openSocket() async {
+  Future<void> _openSocket() async {
+    // A retry's delay may elapse after `close()`; never reopen a closed
+    // connection.
+    if (!_isOpen) {
+      return;
+    }
     if (isSocketConnected) {
-      _closeSocket();
+      return;
+    }
+    await _closeSocket();
+    if (shouldEnableErrorLogging) {
+      print('Opening socket');
     }
     _shouldRetrySocketConnection = true;
     _socket = IOWebSocketChannel.connect(
@@ -166,6 +187,13 @@ class MetricsConnection {
     try {
       await _socket!.ready;
       _resetInactivityTimer();
+      _setConnectionState(ConnectionState.connected);
+      _setServerStatus(ServerState.online);
+      // Do NOT reset the backoff on a bare handshake. A server that accepts
+      // the WS upgrade then immediately drops would otherwise reset the
+      // counter every cycle, pinning reconnects at the 1s floor forever.
+      // Only clear the backoff once the connection has proven stable.
+      _armStabilityReset();
       _socketSubscription = _socket!.stream.listen(
         _onSocketMessage,
         onError: _onSocketError,
@@ -175,33 +203,67 @@ class MetricsConnection {
       if (shouldEnableErrorLogging) {
         print(e);
       }
-      _requestServerHealth();
-      _onSocketDone();
+      // Detach recovery: a persistently failing handshake must not block
+      // `_open()` (which still has to bring REST up) nor chain the reconnect
+      // loop onto the caller's await. The retry runs in the background.
+      unawaited(_requestServerHealth());
+      unawaited(_onSocketDone());
     }
   }
 
-  void _closeSocket() {
-    _inactivityTimer?.cancel();
-    _inactivityTimer = null;
-    _socketSubscription?.cancel();
-    _socketSubscription = null;
-    _socket?.sink.close(socket_status.normalClosure);
-    _socket = null;
-    _setConnectionState(ConnectionState.disconnected);
-    _drainSocket();
-  }
-
-  void _resetInactivityTimer() {
-    _inactivityTimer?.cancel();
-    _inactivityTimer = Timer(const Duration(seconds: 75), () {
-      if (shouldEnableErrorLogging) {
-        print('Socket inactivity timeout');
-      }
-      _onSocketDone();
+  /// Resets the reconnect backoff only after the socket has stayed up for
+  /// [_socketStabilityWindow]. A connection that drops before the window
+  /// elapses leaves [_socketRetryAttempts] climbing, so a flapping server is
+  /// backed off instead of hammered.
+  void _armStabilityReset() {
+    _stabilityTimer?.cancel();
+    _stabilityTimer = Timer(_socketStabilityWindow, () {
+      _socketRetryAttempts = 0;
     });
   }
 
-  void _openRest() {
+  Future<void> _closeSocket() async {
+    // Tear down state SYNCHRONOUSLY (null the socket, flip disconnected) before
+    // any await. The idempotency guard in `_onSocketDone` keys off
+    // `_socket == null && disconnected`; if we awaited first, a racing
+    // onError/onDone could observe the old non-null socket and spawn a second
+    // reconnect loop.
+    _stabilityTimer?.cancel();
+    _stabilityTimer = null;
+    _inactivityTimer?.cancel();
+    _inactivityTimer = null;
+    final subscription = _socketSubscription;
+    final socket = _socket;
+    _socketSubscription = null;
+    _socket = null;
+    _setConnectionState(ConnectionState.disconnected);
+    _drainSocket();
+    // Fire-and-forget the underlying teardown. A channel whose handshake
+    // failed can leave `sink.close()` hanging forever; awaiting it here would
+    // stall the entire reconnect loop (callers await this method). Swallow
+    // errors — the socket is already gone as far as our state is concerned.
+    if (subscription != null) {
+      unawaited(subscription.cancel().catchError((Object _) {}));
+    }
+    if (socket != null) {
+      unawaited(
+        socket.sink.close(socket_status.normalClosure).catchError((Object _) {}),
+      );
+    }
+  }
+
+  Future<void> _resetInactivityTimer() async {
+    _inactivityTimer?.cancel();
+    _inactivityTimer = Timer(const Duration(seconds: 75), () async {
+      if (shouldEnableErrorLogging) {
+        print('Socket inactivity timeout');
+      }
+      await _onSocketDone();
+      await _requestServerHealth();
+    });
+  }
+
+  Future<void> _openRest() async {
     _dio ??= Dio(
       BaseOptions(
         baseUrl: restEndpoint,
@@ -211,6 +273,10 @@ class MetricsConnection {
       ),
     );
     _isDioAvailable = true;
+    if (isSocketConnected) {
+      return;
+    }
+    await _requestServerHealth();
   }
 
   void _closeRest() {
@@ -232,42 +298,49 @@ class MetricsConnection {
       return;
     }
     _closeRest();
+    _retryRestConnection();
   }
 
-  void _onSocketError(error) {
+  Future<void> _onSocketError(error) async {
     _setConnectionState(ConnectionState.disconnected);
-    _onSocketDone();
+    await _onSocketDone();
     if (shouldEnableErrorLogging) {
       print('Socket Error: $error');
     }
   }
 
-  void _onSocketDone() {
-    _closeSocket();
+  Future<void> _onSocketDone() async {
+    // Idempotent teardown. The stream wires both onError and onDone, and the
+    // inactivity timer can race them — without this guard each would spawn its
+    // own retry loop, leaving orphaned sockets. Once torn down (socket null +
+    // disconnected) a duplicate callback is a no-op.
+    if (_socket == null &&
+        _socketConnectionState == ConnectionState.disconnected) {
+      return;
+    }
+    await _closeSocket();
 
     if (_shouldRetrySocketConnection) {
-      _retrySocketConnection();
+      await _retrySocketConnection();
     }
   }
 
-  void _retrySocketConnection() async {
-    int retryTimeout = 0;
-    if (_socketRetryAttempts > 3 && _socketRetryAttempts < 6) {
-      retryTimeout = 2000; // 6 seconds
-    } else if (_socketRetryAttempts >= 6 && _socketRetryAttempts < 20) {
-      retryTimeout = 30000; // 7 minutes
-    } else if (_socketRetryAttempts >= 20 && _socketRetryAttempts < 28) {
-      retryTimeout = 60000; // 8 minutes
-    } else if (_socketRetryAttempts >= 28) {
-      return;
+  Future<void> _retrySocketConnection() async {
+    _socketRetryAttempts++;
+    await Future.delayed(nextReconnectDelay(_socketRetryAttempts));
+    if (shouldEnableErrorLogging) {
+      print('Retrying socket connection...');
     }
-    if (socketRetryTimeout != null) {
-      retryTimeout = socketRetryTimeout!;
-    } else {
-      _socketRetryAttempts++;
+    await _openSocket();
+  }
+
+  Future<void> _retryRestConnection() async {
+    _restRetryAttempts++;
+    await Future.delayed(nextReconnectDelay(_restRetryAttempts));
+    if (shouldEnableErrorLogging) {
+      print('Retrying REST connection...');
     }
-    await Future.delayed(Duration(milliseconds: retryTimeout));
-    _openSocket();
+    await _openRest();
   }
 
   void _setConnectionState(ConnectionState connectionState) {
@@ -275,16 +348,29 @@ class MetricsConnection {
       _setServerStatus(ServerState.online);
     }
 
+    // Only emit on an actual transition. Teardown paths (onError + onDone +
+    // inactivity timer) all flip to disconnected; without this guard consumers
+    // get a burst of duplicate events.
+    if (_socketConnectionState == connectionState) {
+      return;
+    }
     _socketConnectionState = connectionState;
-    _onConnectionChange.add(_socketConnectionState);
+    // `_closeSocket` is async and may settle after `dispose()` has closed the
+    // controllers; guard every emit so a late teardown never throws on a
+    // closed stream.
+    if (!_onConnectionChange.isClosed) {
+      _onConnectionChange.add(_socketConnectionState);
+    }
   }
 
   void _setServerStatus(ServerState status) {
     if (_serverStatus != status) {
       _serverStatus = status;
-      _onServerStatusChange.add(status);
-      if (status == ServerState.offline) {
-        close();
+      if (!_onServerStatusChange.isClosed) {
+        _onServerStatusChange.add(status);
+      }
+      if (_serverStatus == ServerState.online) {
+        _restRetryAttempts = 0;
       }
     }
   }
@@ -298,7 +384,9 @@ class MetricsConnection {
     }
     if (_authenticationStatus != status) {
       _authenticationStatus = status;
-      _onAuthenticationStatusChange.add(status);
+      if (!_onAuthenticationStatusChange.isClosed) {
+        _onAuthenticationStatusChange.add(status);
+      }
     }
   }
 
@@ -339,7 +427,7 @@ class MetricsConnection {
     _socket!.sink.add('"primus::pong::$time"');
   }
 
-  void _requestServerHealth() async {
+  Future<void> _requestServerHealth() async {
     try {
       await _enqueue(
         path: '/status',
@@ -384,7 +472,7 @@ class MetricsConnection {
               // still connected the server is reachable, so lazily rebuild
               // the REST client instead of declaring the server offline.
               if (isSocketConnected) {
-                _openRest();
+                await _openRest();
               } else {
                 _setServerStatus(ServerState.offline);
                 throw UnexpectedError(message: 'Internet or Server is offline');
@@ -433,11 +521,20 @@ class MetricsConnection {
     return response;
   }
 
-  void _dequeue() async {
-    if (_requestQueue.isEmpty) {
-      return;
+  /// Pumps queued requests into execution while there is concurrency budget.
+  /// Every request — first-attempt or queued — flows through here so the
+  /// [_activeRequest] counter is the single source of truth. Each completion
+  /// re-pumps (see [_runQueued]), so the queue can never stall with budget
+  /// free and items still waiting.
+  void _dequeue() {
+    while (_requestQueue.isNotEmpty && _activeRequest < concurrentRequestLimit) {
+      final request = _requestQueue.removeAt(0);
+      _activeRequest++;
+      _runQueued(request);
     }
-    final request = _requestQueue.removeAt(0);
+  }
+
+  Future<void> _runQueued(RequestHandler request) async {
     try {
       final response = await _executeRequest(
           request.path,
@@ -450,6 +547,9 @@ class MetricsConnection {
       request.completer.complete(response);
     } catch (e) {
       request.completer.completeError(e);
+    } finally {
+      _activeRequest--;
+      _dequeue();
     }
   }
 
@@ -461,20 +561,9 @@ class MetricsConnection {
     Map<String, dynamic> queryParameters = const {},
     Map<String, dynamic> socketParameters = const {},
     Map<String, dynamic>? bodyParameters,
-  }) async {
-    if (_activeRequest < concurrentRequestLimit) {
-      _activeRequest++;
-      try {
-        final res = await _executeRequest(path, action, method, shouldRetry,
-            queryParameters, socketParameters, bodyParameters);
-        return res;
-      } finally {
-        _activeRequest--;
-        _dequeue();
-      }
-    }
+  }) {
     final completer = Completer<ResponseMessage>();
-    final requestHandler = RequestHandler(
+    _requestQueue.add(RequestHandler(
         completer: completer,
         path: path,
         action: action,
@@ -482,15 +571,16 @@ class MetricsConnection {
         params: queryParameters,
         socketParams: socketParameters,
         bodyParams: bodyParameters,
-        method: method);
-    _requestQueue.add(requestHandler);
-    final res = await completer.future;
-    return res;
+        method: method));
+    _dequeue();
+    return completer.future;
   }
 
   ResponseMessage _checkIfAuthenticated(ResponseMessage response) {
-    final data = response.data! as Map<String, dynamic>;
-    if (data['accessToken'] != null) {
+    // Runs for every response, so a non-map / null payload (lists, status
+    // bodies) must not crash. Only inspect maps that actually carry a token.
+    final data = response.data;
+    if (data is Map<String, dynamic> && data['accessToken'] != null) {
       _updateTokens(AuthenticatedResponse.fromMap(data));
       _setAuthStatus(AuthenticationState.authenticated);
     }
@@ -501,8 +591,7 @@ class MetricsConnection {
   Future<ResponseMessage> _actionSocket(
     String action,
     Map<String, dynamic> params,
-  ) async {
-    final completer = Completer<ResponseMessage>();
+  ) {
     _lastMessageId++;
     final messageId = _lastMessageId;
     final args = {
@@ -513,19 +602,38 @@ class MetricsConnection {
         ...params,
       },
     };
+    return _awaitSocketResponse(args, messageId, reconnectOnTimeout: true);
+  }
 
+  /// Sends a framed socket request and awaits its correlated response.
+  ///
+  /// Shared by [_actionSocket] and [sendChatRoomMessage]. When
+  /// [reconnectOnTimeout] is true (RPC actions) a timeout tears the socket down
+  /// and reconnects, then throws a retryable [TimeoutException] so the caller's
+  /// retry loop re-routes the request over REST. When false (fire-and-forget
+  /// chat) a timeout simply surfaces as an [UnexpectedError].
+  Future<ResponseMessage> _awaitSocketResponse(
+    Map<String, dynamic> args,
+    int messageId, {
+    required bool reconnectOnTimeout,
+  }) async {
+    final completer = Completer<ResponseMessage>();
     _completers[messageId] = completer;
     try {
       _socket?.sink.add(jsonEncode(args));
-      final response = await completer.future.timeout(socketMessageTimeout);
-      return response;
+      return await completer.future.timeout(socketMessageTimeout);
     } on TimeoutException catch (_) {
-      if (_completers.containsKey(messageId)) {
-        _completers.remove(messageId);
+      _completers.remove(messageId);
+      if (reconnectOnTimeout) {
+        // Socket is unresponsive: tear it down + reconnect, and throw a
+        // retryable error so `_executeRequest`'s retry falls back to REST.
+        unawaited(_onSocketDone());
+        throw TimeoutException('Socket message timeout');
       }
       _setConnectionState(ConnectionState.disconnected);
       throw UnexpectedError(message: 'Socket message timeout');
     } catch (error) {
+      _completers.remove(messageId);
       if (error is Map<String, dynamic>) {
         throw MetricsApiError.fromMap(error);
       }
@@ -688,11 +796,41 @@ class MetricsConnection {
     } on MetricsApiError catch (error) {
       if (error.code == 616) {
         // 616 -> invalid token
-        if (_refreshToken != null) {
-          if (_isRefreshTokenInUse) {
+        if (_refreshToken == null) {
+          // invalid token and no refresh token
+          _setAuthStatus(AuthenticationState.unauthenticated);
+          rethrow;
+        }
+        if (_isRefreshTokenInUse) {
+          // A refresh is already in flight. Spending the refresh token a
+          // second time concurrently risks blacklisting it, so wait for the
+          // in-flight refresh and then retry this request with the freshly
+          // issued access token.
+          try {
+            await _refreshCompleter?.future;
+          } catch (_) {
+            // Refresh failed; the original 616 stands.
             rethrow;
           }
+          response = await _enqueue(
+            action: action,
+            queryParameters: {
+              'authorization': _accessToken,
+              ...queryParameters,
+            },
+            socketParameters: socketParameters,
+            bodyParameters: bodyParameters,
+            method: method,
+            path: path,
+          );
+        } else {
           _isRefreshTokenInUse = true;
+          final refreshCompleter = Completer<void>();
+          _refreshCompleter = refreshCompleter;
+          // The refresher reports failure to itself via `rethrow`; this guard
+          // stops the shared future from surfacing an unhandled async error
+          // when no concurrent request happens to be awaiting it.
+          refreshCompleter.future.ignore();
           try {
             response = await _enqueue(
               action: action,
@@ -700,25 +838,30 @@ class MetricsConnection {
                 'authorization': _refreshToken,
                 ...queryParameters,
               },
+              socketParameters: socketParameters,
+              bodyParameters: bodyParameters,
               method: method,
               path: path,
             );
+            // Publish the new access token before releasing waiters so their
+            // retry picks it up.
+            _checkIfAuthenticated(response);
+            refreshCompleter.complete();
           } on MetricsApiError catch (error) {
             if (error.code == 615 || error.code == 616) {
               // 615 -> blacklisted token
               // 616 -> invalid token
               _setAuthStatus(AuthenticationState.unauthenticated);
             }
+            refreshCompleter.completeError(error);
             rethrow;
-          } catch (_) {
+          } catch (e) {
+            refreshCompleter.completeError(e);
             rethrow;
           } finally {
             _isRefreshTokenInUse = false;
+            _refreshCompleter = null;
           }
-        } else {
-          // invalid token and no refresh token
-          _setAuthStatus(AuthenticationState.unauthenticated);
-          rethrow;
         }
       } else if (error.code == 615 ||
           (error.code == 613 && _accessToken == null)) {
@@ -739,8 +882,7 @@ class MetricsConnection {
   Future<ResponseMessage> sendChatRoomMessage({
     required String room,
     required Map<String, dynamic> params,
-  }) async {
-    final completer = Completer<ResponseMessage>();
+  }) {
     _lastMessageId++;
     final messageId = _lastMessageId;
     final args = {
@@ -752,23 +894,7 @@ class MetricsConnection {
         ...params,
       },
     };
-
-    _completers[messageId] = completer;
-    try {
-      _socket?.sink.add(jsonEncode(args));
-      final response = await completer.future.timeout(socketMessageTimeout);
-      return response;
-    } on TimeoutException catch (_) {
-      _completers.remove(messageId);
-      _setConnectionState(ConnectionState.disconnected);
-      throw UnexpectedError(message: 'Socket message timeout');
-    } catch (error) {
-      _completers.remove(messageId);
-      if (error is Map<String, dynamic>) {
-        throw MetricsApiError.fromMap(error);
-      }
-      throw UnexpectedError(message: error.toString());
-    }
+    return _awaitSocketResponse(args, messageId, reconnectOnTimeout: false);
   }
 
   /// Closes and disposes everything within the connection class.

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -19,6 +19,7 @@ class MetricsConnection {
     this.concurrentRequestLimit = defaultConcurrentRequestLimit,
     this.requestRetryLimit = defaultRequestRetryLimit,
     this.shouldEnableErrorLogging = false,
+    this.connectionReconnectDelay,
   }) {
     unawaited(_open());
   }
@@ -30,6 +31,7 @@ class MetricsConnection {
   final int requestRetryLimit;
   final Duration socketTimeout;
   final Duration socketMessageTimeout;
+  final Duration? connectionReconnectDelay;
   final bool shouldEnableErrorLogging;
 
   // internal
@@ -247,7 +249,9 @@ class MetricsConnection {
     }
     if (socket != null) {
       unawaited(
-        socket.sink.close(socket_status.normalClosure).catchError((Object _) {}),
+        socket.sink
+            .close(socket_status.normalClosure)
+            .catchError((Object _) {}),
       );
     }
   }
@@ -327,7 +331,9 @@ class MetricsConnection {
 
   Future<void> _retrySocketConnection() async {
     _socketRetryAttempts++;
-    await Future.delayed(_nextReconnectDelay(_socketRetryAttempts));
+    final delay =
+        connectionReconnectDelay ?? _nextReconnectDelay(_socketRetryAttempts);
+    await Future.delayed(delay);
     if (shouldEnableErrorLogging) {
       print('Retrying socket connection...');
     }
@@ -336,7 +342,9 @@ class MetricsConnection {
 
   Future<void> _retryRestConnection() async {
     _restRetryAttempts++;
-    await Future.delayed(_nextReconnectDelay(_restRetryAttempts));
+    final delay =
+        connectionReconnectDelay ?? _nextReconnectDelay(_restRetryAttempts);
+    await Future.delayed(delay);
     if (shouldEnableErrorLogging) {
       print('Retrying REST connection...');
     }
@@ -527,7 +535,8 @@ class MetricsConnection {
   /// re-pumps (see [_runQueued]), so the queue can never stall with budget
   /// free and items still waiting.
   void _dequeue() {
-    while (_requestQueue.isNotEmpty && _activeRequest < concurrentRequestLimit) {
+    while (
+        _requestQueue.isNotEmpty && _activeRequest < concurrentRequestLimit) {
       final request = _requestQueue.removeAt(0);
       _activeRequest++;
       _runQueued(request);

--- a/lib/src/connection.dart
+++ b/lib/src/connection.dart
@@ -41,6 +41,7 @@ class MetricsConnection {
   int _socketRetryAttempts = 0;
   int _restRetryAttempts = 0;
   bool _shouldRetrySocketConnection = true;
+  bool _isRestRetrying = false;
   bool _isDioAvailable = false;
   final List<RequestHandler> _requestQueue = [];
   final Map<int, Completer> _completers = {};
@@ -302,7 +303,13 @@ class MetricsConnection {
       return;
     }
     _closeRest();
-    _retryRestConnection();
+    // Single-flight: only one reconnect loop may run. Without this guard every
+    // concurrent request that hits a connection-class error spawns its own
+    // loop, all sharing `_restRetryAttempts` — the counter races up, the
+    // backoff tier escalates far faster than wall-clock warrants, and the
+    // loops tear down each other's freshly-built Dio. The running loop's own
+    // health-check failure re-enters here and is absorbed by the guard.
+    unawaited(_retryRestConnection());
   }
 
   Future<void> _onSocketError(error) async {
@@ -333,6 +340,10 @@ class MetricsConnection {
     _socketRetryAttempts++;
     final delay =
         connectionReconnectDelay ?? _nextReconnectDelay(_socketRetryAttempts);
+    if (shouldEnableErrorLogging) {
+      print(
+          'Socket Retry Attempt $_socketRetryAttempts, Delay: $delay, Date: ${DateTime.now().toUtc()}');
+    }
     await Future.delayed(delay);
     if (shouldEnableErrorLogging) {
       print('Retrying socket connection...');
@@ -341,14 +352,35 @@ class MetricsConnection {
   }
 
   Future<void> _retryRestConnection() async {
-    _restRetryAttempts++;
-    final delay =
-        connectionReconnectDelay ?? _nextReconnectDelay(_restRetryAttempts);
-    await Future.delayed(delay);
-    if (shouldEnableErrorLogging) {
-      print('Retrying REST connection...');
+    // Single self-contained loop. Re-entrant callers (each failing request)
+    // are absorbed here so only one backoff chain runs at a time.
+    if (_isRestRetrying) {
+      return;
     }
-    await _openRest();
+    _isRestRetrying = true;
+    try {
+      // Keep retrying while the connection is open, REST is down, and no
+      // socket is vouching for the server. `_openRest`'s health check on
+      // failure calls `_handleRestConnectionFailure` -> `_closeRest` (clears
+      // `_isDioAvailable`), so the loop condition stays true until a probe
+      // succeeds (Dio survives) or the socket reconnects.
+      while (_isOpen && !_isDioAvailable && !isSocketConnected) {
+        _restRetryAttempts++;
+        final delay =
+            connectionReconnectDelay ?? _nextReconnectDelay(_restRetryAttempts);
+        if (shouldEnableErrorLogging) {
+          print(
+              'Rest Retry Attempt $_restRetryAttempts, Delay: $delay, Date: ${DateTime.now()}');
+        }
+        await Future.delayed(delay);
+        if (shouldEnableErrorLogging) {
+          print('Retrying REST connection...');
+        }
+        await _openRest();
+      }
+    } finally {
+      _isRestRetrying = false;
+    }
   }
 
   void _setConnectionState(ConnectionState connectionState) {

--- a/lib/src/connection_helpers.dart
+++ b/lib/src/connection_helpers.dart
@@ -1,0 +1,22 @@
+part of '../keiser_metrics_connection.dart';
+
+final _maxReconnectDelay = Duration(minutes: 5);
+final _random = Random();
+
+int _cloudReconnectDelayMs(int attempt) {
+  if (attempt < 10) {
+    return 1000;
+  }
+  if (attempt < 20) {
+    return 2000;
+  }
+  final tierIndex = ((attempt - 20) ~/ 5).clamp(0, 16);
+  final delayMs = 4000 * (1 << tierIndex);
+  return delayMs.clamp(4000, _maxReconnectDelay.inMilliseconds);
+}
+
+Duration nextReconnectDelay(int reconnectAttempts) {
+  final capped = _cloudReconnectDelayMs(reconnectAttempts);
+  final jittered = capped * (0.8 + _random.nextDouble() * 0.4);
+  return Duration(milliseconds: jittered.round());
+}

--- a/lib/src/connection_helpers.dart
+++ b/lib/src/connection_helpers.dart
@@ -15,7 +15,7 @@ int _cloudReconnectDelayMs(int attempt) {
   return delayMs.clamp(4000, _maxReconnectDelay.inMilliseconds);
 }
 
-Duration nextReconnectDelay(int reconnectAttempts) {
+Duration _nextReconnectDelay(int reconnectAttempts) {
   final capped = _cloudReconnectDelayMs(reconnectAttempts);
   final jittered = capped * (0.8 + _random.nextDouble() * 0.4);
   return Duration(milliseconds: jittered.round());

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,4 +1,4 @@
-part of keiser_metrics_connection;
+part of '../keiser_metrics_connection.dart';
 
 enum WebsocketMessageContext { response, user }
 

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -15,3 +15,8 @@ const defaultSocketConnectionTimeout = Duration(seconds: 30);
 const defaultSocketMessageTimeout = Duration(seconds: 45);
 const defaultConcurrentRequestLimit = 5;
 const defaultRequestRetryLimit = 5;
+
+/// How long a websocket must stay connected before its successful connection
+/// clears the reconnect backoff. Guards against a server that accepts the
+/// handshake then immediately drops resetting the backoff every cycle.
+const _socketStabilityWindow = Duration(seconds: 10);

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -1,4 +1,4 @@
-part of keiser_metrics_connection;
+part of '../keiser_metrics_connection.dart';
 
 class MetricsApiError implements Exception {
   MetricsApiError({
@@ -54,9 +54,8 @@ class MetricsApiError implements Exception {
 }
 
 class UnexpectedError extends MetricsApiError {
-  UnexpectedError({required String message})
-      : super(
-            code: -1, status: 500, name: 'Unexpected Error', message: message);
+  UnexpectedError({required super.message})
+      : super(code: -1, status: 500, name: 'Unexpected Error');
 
   @override
   String toString() {

--- a/lib/src/jwt.dart
+++ b/lib/src/jwt.dart
@@ -1,4 +1,4 @@
-part of keiser_metrics_connection;
+part of '../keiser_metrics_connection.dart';
 
 JWTToken decodeJwt(String token) {
   final jwtToken = JwtDecoder.decode(token);

--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -1,4 +1,4 @@
-part of keiser_metrics_connection;
+part of '../keiser_metrics_connection.dart';
 
 class ConnectionStateEvent {
   final ConnectionState connectionState;

--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -1,4 +1,4 @@
-part of keiser_metrics_connection;
+part of '../keiser_metrics_connection.dart';
 
 AuthenticatedResponse authenticatedResponseFromMap(String str) =>
     AuthenticatedResponse.fromMap(json.decode(str));

--- a/test/connection_backoff_test.dart
+++ b/test/connection_backoff_test.dart
@@ -1,0 +1,83 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:keiser_metrics_connection/keiser_metrics_connection.dart';
+import 'package:test/test.dart';
+
+/// Completes the WS handshake then immediately drops the socket, simulating a
+/// server that is reachable at the TCP/HTTP layer but cannot hold a session.
+class _FlapServer {
+  _FlapServer(this._server) {
+    _server.listen(_handle);
+  }
+
+  static Future<_FlapServer> start() async {
+    final s = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    return _FlapServer(s);
+  }
+
+  final HttpServer _server;
+  final List<DateTime> connectTimes = [];
+
+  int get port => _server.port;
+  String get restEndpoint => 'http://127.0.0.1:$port/api';
+  String get socketEndpoint => 'ws://127.0.0.1:$port/ws';
+
+  Future<void> _handle(HttpRequest request) async {
+    if (request.uri.path == '/ws') {
+      connectTimes.add(DateTime.now());
+      final ws = await WebSocketTransformer.upgrade(request);
+      await ws.close();
+      return;
+    }
+    // Status probes from the reconnect path; keep them cheap.
+    await request.drain<void>();
+    request.response.write(jsonEncode({'name': 'fake'}));
+    await request.response.close();
+  }
+
+  Future<void> close() => _server.close(force: true);
+}
+
+void main() {
+  test(
+    'reconnect backoff climbs against a server that drops every handshake',
+    () async {
+      final server = await _FlapServer.start();
+      final connection = MetricsConnection(
+        restEndpoint: server.restEndpoint,
+        socketEndpoint: server.socketEndpoint,
+      );
+
+      // Long enough to cross the tier-10 boundary in nextReconnectDelay, where
+      // the per-attempt delay first grows past the 1s floor.
+      await Future.delayed(const Duration(seconds: 16));
+      await connection.dispose();
+      await server.close();
+
+      final times = server.connectTimes;
+      expect(times.length, greaterThan(3),
+          reason: 'the client must keep retrying, not give up');
+
+      final gaps = <int>[
+        for (var i = 1; i < times.length; i++)
+          times[i].difference(times[i - 1]).inMilliseconds,
+      ];
+
+      // The bug: a successful handshake reset _socketRetryAttempts to 0 every
+      // cycle, pinning every gap at the ~1s floor. With the fix the counter
+      // climbs (handshake alone no longer counts as stable), so once attempts
+      // pass tier 10 the delay grows past the floor.
+      final maxGap = gaps.fold<int>(0, (m, g) => g > m ? g : m);
+      expect(maxGap, greaterThan(1700),
+          reason: 'backoff must grow beyond the 1s floor under a flapping '
+              'server; gaps observed: $gaps');
+
+      // And it must not hammer the server at ~1/sec for the whole window.
+      expect(times.length, lessThan(16),
+          reason: 'too many attempts implies the backoff never engaged');
+    },
+    timeout: const Timeout(Duration(seconds: 40)),
+  );
+}

--- a/test/connection_handshake_test.dart
+++ b/test/connection_handshake_test.dart
@@ -1,0 +1,72 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:keiser_metrics_connection/keiser_metrics_connection.dart';
+import 'package:test/test.dart';
+
+/// Raw TCP listener that accepts a connection then destroys it without sending
+/// any HTTP response. Both the REST probe and the WS upgrade fail with
+/// "connection closed before full header was received" — the failure mode from
+/// the field logs, where the websocket handshake itself never completes.
+void main() {
+  test(
+    'a failing websocket handshake does not deadlock the reconnect loop',
+    () async {
+      final raw = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+      var accepts = 0;
+      final sub = raw.listen((socket) {
+        accepts++;
+        socket.destroy();
+      });
+
+      final port = raw.port;
+      final connection = MetricsConnection(
+        restEndpoint: 'http://127.0.0.1:$port/api',
+        socketEndpoint: 'ws://127.0.0.1:$port/ws',
+      );
+
+      // Let several reconnect cycles elapse.
+      await Future.delayed(const Duration(seconds: 6));
+      final acceptsAfter6s = accepts;
+
+      await connection.dispose();
+      await sub.cancel();
+      await raw.close();
+
+      // Pre-fix, `_closeSocket` awaited `sink.close()` on the never-established
+      // channel, which hung forever — the socket retried exactly once and then
+      // the loop was dead (accepts stuck at 1). The loop must keep cycling.
+      expect(acceptsAfter6s, greaterThan(4),
+          reason: 'reconnect loop must keep retrying after a handshake failure, '
+              'not deadlock on the first attempt (accepts=$acceptsAfter6s)');
+    },
+    timeout: const Timeout(Duration(seconds: 30)),
+  );
+
+  test('reconnect loop stops once the connection is disposed', () async {
+    final raw = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+    var accepts = 0;
+    final sub = raw.listen((socket) {
+      accepts++;
+      socket.destroy();
+    });
+
+    final port = raw.port;
+    final connection = MetricsConnection(
+      restEndpoint: 'http://127.0.0.1:$port/api',
+      socketEndpoint: 'ws://127.0.0.1:$port/ws',
+    );
+
+    await Future.delayed(const Duration(seconds: 2));
+    await connection.dispose();
+    final acceptsAtDispose = accepts;
+
+    // After dispose, no further connection attempts should be made.
+    await Future.delayed(const Duration(seconds: 3));
+    expect(accepts, acceptsAtDispose,
+        reason: 'dispose must halt reconnect attempts');
+
+    await sub.cancel();
+    await raw.close();
+  });
+}

--- a/test/connection_queue_auth_test.dart
+++ b/test/connection_queue_auth_test.dart
@@ -1,0 +1,226 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:keiser_metrics_connection/keiser_metrics_connection.dart';
+import 'package:test/test.dart';
+
+/// Builds an unsigned JWT whose payload decodes to a [MachineSessionToken]
+/// (role == 'machine'). That token type carries no `exp`, so `_updateTokens`
+/// skips the keep-alive timer — exactly what these token-plumbing tests want.
+String _machineJwt(String jti) {
+  String seg(Map<String, dynamic> m) =>
+      base64Url.encode(utf8.encode(jsonEncode(m))).replaceAll('=', '');
+  final header = seg({'alg': 'none', 'typ': 'JWT'});
+  final body = seg({
+    'role': 'machine',
+    'type': 'machine',
+    'iss': 'fake',
+    'jti': jti,
+    'machine': {'id': 1},
+  });
+  return '$header.$body.sig';
+}
+
+/// In-process HTTP/WS server for queue + auth tests. REST-only (socket disabled
+/// by the tests), so `/ws` is unused here.
+class _FakeServer {
+  _FakeServer(this._server) {
+    _server.listen(_handle);
+  }
+
+  static Future<_FakeServer> start() async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    return _FakeServer(server);
+  }
+
+  final HttpServer _server;
+
+  // /api/concurrent bookkeeping.
+  int _activeConcurrent = 0;
+  int maxConcurrent = 0;
+  int concurrentHits = 0;
+
+  // /api/protected auth bookkeeping.
+  final String accessTokenA = _machineJwt('access-a');
+  final String accessTokenB = _machineJwt('access-b');
+  String refreshToken = 'refresh-1';
+  String? _validAccessToken; // null => the seeded access token is "expired".
+  int refreshUses = 0;
+  int protectedSuccesses = 0;
+
+  int get port => _server.port;
+  String get restEndpoint => 'http://127.0.0.1:$port/api';
+  String get socketEndpoint => 'ws://127.0.0.1:$port/ws';
+
+  Future<void> _handle(HttpRequest request) async {
+    final res = request.response;
+    res.headers.contentType = ContentType.json;
+    switch (request.uri.path) {
+      case '/api/concurrent':
+        await request.drain<void>();
+        concurrentHits++;
+        _activeConcurrent++;
+        if (_activeConcurrent > maxConcurrent) {
+          maxConcurrent = _activeConcurrent;
+        }
+        // Hold the request open so overlapping requests actually coexist.
+        await Future.delayed(const Duration(milliseconds: 50));
+        _activeConcurrent--;
+        res.write(jsonEncode({'ok': true}));
+        await res.close();
+        break;
+
+      case '/api/signin':
+        await request.drain<void>();
+        res.write(jsonEncode({
+          'accessToken': accessTokenA,
+          'refreshToken': refreshToken,
+        }));
+        await res.close();
+        break;
+
+      case '/api/protected':
+        await request.drain<void>();
+        final auth = request.uri.queryParameters['authorization'];
+        if (auth == refreshToken) {
+          // Refresh exchange: issue a brand-new access token and mark it valid.
+          refreshUses++;
+          _validAccessToken = accessTokenB;
+          refreshToken = 'refresh-2';
+          res.write(jsonEncode({
+            'accessToken': accessTokenB,
+            'refreshToken': refreshToken,
+            'ok': true,
+          }));
+          await res.close();
+        } else if (auth != null && auth == _validAccessToken) {
+          protectedSuccesses++;
+          res.write(jsonEncode({'ok': true}));
+          await res.close();
+        } else {
+          // Expired / invalid access token -> 616.
+          res.statusCode = 400;
+          res.write(jsonEncode({
+            'error': {
+              'code': 616,
+              'status': 400,
+              'name': 'InvalidToken',
+              'message': 'invalid token',
+            },
+          }));
+          await res.close();
+        }
+        break;
+
+      default:
+        res.statusCode = 404;
+        await res.close();
+    }
+  }
+
+  Future<void> close() => _server.close(force: true);
+}
+
+void main() {
+  late _FakeServer server;
+
+  setUp(() async {
+    server = await _FakeServer.start();
+  });
+
+  tearDown(() async {
+    await server.close();
+  });
+
+  test(
+      'queued requests beyond the concurrency limit all complete and never '
+      'exceed the limit', () async {
+    final connection = MetricsConnection(
+      restEndpoint: server.restEndpoint,
+      socketEndpoint: server.socketEndpoint,
+      shouldEnableWebSocket: false,
+      concurrentRequestLimit: 2,
+      requestRetryLimit: 1,
+    );
+
+    // Fire far more than the limit. Pre-fix, the queue drained one item per
+    // active completion and stalled once the active set hit zero, so this
+    // Future.wait would hang. It must now resolve every request.
+    final futures = List.generate(
+      10,
+      (_) => connection.action(
+        path: '/concurrent',
+        action: 'test:concurrent',
+        method: 'GET',
+      ),
+    );
+
+    final responses = await Future.wait(futures).timeout(
+      const Duration(seconds: 10),
+      onTimeout: () => fail('queue stalled: not all requests completed'),
+    );
+
+    expect(responses, hasLength(10));
+    expect(server.concurrentHits, 10,
+        reason: 'every queued request must reach the server');
+    expect(server.maxConcurrent, lessThanOrEqualTo(2),
+        reason: 'concurrency limit must be enforced for queued items too');
+    expect(server.maxConcurrent, greaterThan(1),
+        reason: 'requests should actually run concurrently up to the limit');
+
+    await connection.dispose();
+  });
+
+  test(
+      'concurrent 616s trigger a single token refresh and all requests then '
+      'succeed', () async {
+    final connection = MetricsConnection(
+      restEndpoint: server.restEndpoint,
+      socketEndpoint: server.socketEndpoint,
+      shouldEnableWebSocket: false,
+      concurrentRequestLimit: 10,
+      requestRetryLimit: 1,
+    );
+
+    // Seed access + refresh tokens via a sign-in response.
+    await connection.action(
+      path: '/signin',
+      action: 'auth:signin',
+      method: 'GET',
+    );
+
+    // Five requests fire together. Each gets a 616 on the (expired) access
+    // token. Only the first may spend the refresh token; the rest must wait
+    // for that refresh and retry with the freshly issued access token.
+    final futures = List.generate(
+      5,
+      (_) => connection.action(
+        path: '/protected',
+        action: 'test:protected',
+        method: 'GET',
+      ),
+    );
+
+    final responses = await Future.wait(futures).timeout(
+      const Duration(seconds: 10),
+      onTimeout: () => fail('refresh race deadlocked'),
+    );
+
+    expect(responses, hasLength(5));
+    expect(
+      responses.every((r) => (r.data as Map<String, dynamic>)['ok'] == true),
+      isTrue,
+      reason: 'every request must ultimately succeed after the refresh',
+    );
+    expect(server.refreshUses, 1,
+        reason: 'the refresh token must be spent exactly once, not per-request');
+    // The single refresher is served by the refresh-exchange response itself;
+    // the other four wait on it and retry against the protected route with the
+    // new access token.
+    expect(server.protectedSuccesses, 4,
+        reason: 'the non-refresher requests must retry with the new token');
+
+    await connection.dispose();
+  });
+}


### PR DESCRIPTION
Rework socket/REST reconnection, request queue, and auth refresh
Overhauls the connection lifecycle in MetricsConnection to fix reconnect storms, request-queue stalls, and concurrent token-refresh races. Also migrates to IOWebSocketChannel for native ping/keep-alive and modernizes the part of directives.

Motivation
The previous reconnect logic could spawn multiple concurrent retry loops, reset its backoff on a server that accepted the handshake then immediately dropped (pinning reconnects at the 1s floor), and leak lifecycle timers after close(). The request queue executed first-attempt and queued requests through separate paths, and a concurrent 616 (invalid token) could spend the refresh token twice and get it blacklisted.

Changes
WebSocket transport

Switch from WebSocketChannel to IOWebSocketChannel with native connectTimeout and built-in pinging (replaces app-level ping to server).
Add a 75s inactivity timer that tears down and reconnects a silent socket.
Add a 10s stability window (_socketStabilityWindow): backoff resets only after a connection proves stable, so a flapping server is backed off instead of hammered.
Reconnect backoff (connection_helpers.dart)

New jittered, tiered backoff (_nextReconnectDelay): 1s → 2s → exponential, capped at 5min, with ±20% jitter.
Optional connectionReconnectDelay constructor param overrides the curve with a fixed delay.
Removed the old socketRetryTimeout param.
Single-flight reconnect loops

Socket and REST each guard against concurrent reconnect loops. Re-entrant callers (every failing request) are absorbed so only one backoff chain runs and the shared attempt counter doesn't race up.
Idempotent socket teardown: onError + onDone + inactivity timer can no longer each spawn their own loop.
Request queue

Unified _dequeue / _runQueued pump — first-attempt and queued requests both flow through the _activeRequest counter, which is now the single source of truth. Each completion re-pumps, so the queue can't stall with free budget and items waiting.
Auth refresh

Concurrent 616s now coalesce on a shared _refreshCompleter: in-flight refresh is awaited and the request retried with the new token, instead of spending the refresh token twice.
Robustness

close() now tears down all lifecycle timers (incl. the access-token keep-alive) and resets backoff counters.
Guard every stream emit against closed controllers so a late async teardown doesn't throw.
_setConnectionState only emits on real transitions (no duplicate-event bursts).
_checkIfAuthenticated tolerates non-map / null payloads.
Tests
Adds coverage for backoff, handshake, and queue/auth behavior:

test/connection_backoff_test.dart
test/connection_handshake_test.dart
test/connection_queue_auth_test.dart